### PR TITLE
add dynamic Spark package resolution and default Iceberg REST packages for Polaris

### DIFF
--- a/.build/ci-versions.yml
+++ b/.build/ci-versions.yml
@@ -27,6 +27,11 @@ versions:
     java_version: [11]
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
+    packages:
+      - org.apache.iceberg:iceberg-spark-runtime-3.2_${scala_version}:1.4.3
+      - org.apache.iceberg:iceberg-aws-bundle:1.4.3
+      - io.okdp:okdp-spark-auth-filter:1.4.2
+      - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # Maximum python version supported by spark-3.3.x: 3.10
   # Java support: 8/11/17
   - python_version: '3.10'
@@ -34,6 +39,11 @@ versions:
     java_version: [17]
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
+    packages:
+      - org.apache.iceberg:iceberg-spark-runtime-3.3_${scala_version}:1.8.1
+      - org.apache.iceberg:iceberg-aws-bundle:1.8.1
+      - io.okdp:okdp-spark-auth-filter:1.4.2
+      - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # # # Maximum python version supported by spark-3.4.x: 3.11
   # Java support: 8/11/17
   - python_version: 3.11
@@ -41,6 +51,11 @@ versions:
     java_version: [17]
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
+    packages:
+      - org.apache.iceberg:iceberg-spark-runtime-3.4_${scala_version}:1.10.1
+      - org.apache.iceberg:iceberg-aws-bundle:1.10.1
+      - io.okdp:okdp-spark-auth-filter:1.4.2
+      - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # https://spark.apache.org/releases/spark-release-3-5-0.html
   # # Minimum supported java version: 17/21
   - python_version: 3.11
@@ -48,3 +63,23 @@ versions:
     java_version: [17]
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
+    packages:
+      # List of extra runtime jars to bake into the Spark image.
+      #
+      # Supported entry types:
+      # - Maven coordinates:
+      #     groupId:artifactId:version
+      #     groupId:artifactId:version:type
+      #     groupId:artifactId:version:type:classifier
+      # - Direct jar URL:
+      #     https://...
+      #
+      # Notes:
+      # - ${scala_version} is replaced during matrix expansion with the current Scala version.
+      # - Maven coordinates are resolved with Maven, including transitive dependencies.
+      # - Direct URLs are downloaded as-is and do not resolve transitive dependencies.
+      # - Keep this list compatible with the current Spark / Scala line.
+      - org.apache.iceberg:iceberg-spark-runtime-3.5_${scala_version}:1.10.1
+      - org.apache.iceberg:iceberg-aws-bundle:1.10.1
+      - io.okdp:okdp-spark-auth-filter:1.4.2
+      - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar

--- a/.build/release-versions.yml
+++ b/.build/release-versions.yml
@@ -27,6 +27,8 @@ versions:
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
     packages:
+      - org.apache.iceberg:iceberg-spark-runtime-3.2_${scala_version}:1.4.3
+      - org.apache.iceberg:iceberg-aws-bundle:1.4.3
       - io.okdp:okdp-spark-auth-filter:1.4.2
       - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # Maximum python version supported by spark-3.3.x: 3.10
@@ -37,6 +39,8 @@ versions:
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
     packages:
+      - org.apache.iceberg:iceberg-spark-runtime-3.3_${scala_version}:1.8.1
+      - org.apache.iceberg:iceberg-aws-bundle:1.8.1
       - io.okdp:okdp-spark-auth-filter:1.4.2
       - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # Maximum python version supported by spark-3.4.x: 3.11
@@ -47,6 +51,8 @@ versions:
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
     packages:
+      - org.apache.iceberg:iceberg-spark-runtime-3.4_${scala_version}:1.10.1
+      - org.apache.iceberg:iceberg-aws-bundle:1.10.1
       - io.okdp:okdp-spark-auth-filter:1.4.2
       - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # https://spark.apache.org/releases/spark-release-3-5-0.html
@@ -72,5 +78,7 @@ versions:
       # - Maven coordinates are resolved with Maven, including transitive dependencies.
       # - Direct URLs are downloaded as-is and do not resolve transitive dependencies.
       # - Keep this list compatible with the current Spark / Scala line.
+      - org.apache.iceberg:iceberg-spark-runtime-3.5_${scala_version}:1.10.1
+      - org.apache.iceberg:iceberg-aws-bundle:1.10.1
       - io.okdp:okdp-spark-auth-filter:1.4.2
       - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar

--- a/.build/release-versions.yml
+++ b/.build/release-versions.yml
@@ -26,6 +26,9 @@ versions:
     java_version: [11]
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
+    packages:
+      - io.okdp:okdp-spark-auth-filter:1.4.2
+      - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # Maximum python version supported by spark-3.3.x: 3.10
   # Java support: 8/11/17
   - python_version: '3.10'
@@ -33,6 +36,9 @@ versions:
     java_version: [17]
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
+    packages:
+      - io.okdp:okdp-spark-auth-filter:1.4.2
+      - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # Maximum python version supported by spark-3.4.x: 3.11
   # Java support: 8/11/17
   - python_version: 3.11
@@ -40,6 +46,9 @@ versions:
     java_version: [17]
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
+    packages:
+      - io.okdp:okdp-spark-auth-filter:1.4.2
+      - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
   # https://spark.apache.org/releases/spark-release-3-5-0.html
   # Minimum supported java version: 17/21
   - python_version: 3.11
@@ -47,4 +56,21 @@ versions:
     java_version: [17]
     scala_version: [2.12, 2.13]
     hadoop_version: 3.3.6
-
+    packages:
+      # List of extra runtime jars to bake into the Spark image.
+      #
+      # Supported entry types:
+      # - Maven coordinates:
+      #     groupId:artifactId:version
+      #     groupId:artifactId:version:type
+      #     groupId:artifactId:version:type:classifier
+      # - Direct jar URL:
+      #     https://...
+      #
+      # Notes:
+      # - ${scala_version} is replaced during matrix expansion with the current Scala version.
+      # - Maven coordinates are resolved with Maven, including transitive dependencies.
+      # - Direct URLs are downloaded as-is and do not resolve transitive dependencies.
+      # - Keep this list compatible with the current Spark / Scala line.
+      - io.okdp:okdp-spark-auth-filter:1.4.2
+      - https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar

--- a/.github/actions/spark-version-matrix/action.yml
+++ b/.github/actions/spark-version-matrix/action.yml
@@ -32,24 +32,58 @@ runs:
   steps:
     - name: Generate Matrix
       id: generate-matrix
-      run: |
+      run: |        
+          INPUT_MATRIX=$(yq -oj ${{ inputs.use_matrix }} | jq ' .versions | [ 
+            .[] as $v
+            | $v.spark_version[] as $spark
+            | $v.scala_version[] as $scala
+            | $v.java_version[] as $java
+            | {
+                python_version: $v.python_version,
+                hadoop_version: $v.hadoop_version,
+                spark_version: $spark,
+                scala_version: $scala,
+                java_version: $java,
+                packages: (
+                  ($v.packages // [])
+                  | map(gsub("\\$\\{scala_version\\}"; ($scala | tostring)))
+                  | join(",")
+                )
+            }
+          ]' | jq -c '.')
 
-          INPUT_MATRIX=$(yq -oj ${{ inputs.use_matrix }} | jq '.versions | .[] | 
-               {python_version: .python_version, 
-               hadoop_version: .hadoop_version} + 
-               (.spark_version[] | {spark_version: .}) + 
-               (.scala_version[] | {scala_version: .}) +
-               (.java_version[] | {java_version: .})' | jq -c --slurp '.')
-          REF_MATRIX=$(yq -oj .build/reference-versions.yml | jq '.versions | .[] | 
-               {python_version: .python_version, 
-               hadoop_version: .hadoop_version} + 
-               (.spark_version[] | {spark_version: .}) + 
-               (.scala_version[] | {scala_version: .}) +
-               (.java_version[] | {java_version: .})' | jq -c --slurp '.')
+          REF_MATRIX=$(yq -oj .build/reference-versions.yml | jq ' .versions | [
+            .[] as $v
+            | $v.spark_version[] as $spark
+            | $v.scala_version[] as $scala
+            | $v.java_version[] as $java
+            | {
+                python_version: $v.python_version,
+                hadoop_version: $v.hadoop_version,
+                spark_version: $spark,
+                scala_version: $scala,
+                java_version: $java
+            }
+          ]' | jq -c '.')
 
           ### Intersection between the versions matrix and the reference versions matrix 
           ### When the intersection is empty, the jobs are skipped!
-          MATRIX=$(jq --argjson IN ${INPUT_MATRIX} --argjson REF ${REF_MATRIX} -cn '$IN - ($IN- $REF)')
+          MATRIX=$(jq --argjson IN "${INPUT_MATRIX}" --argjson REF "${REF_MATRIX}" -cn '
+            $IN | 
+              map(
+                . as $row | 
+                  select(
+                    $REF
+                    | index({
+                        python_version: $row.python_version,
+                        hadoop_version: $row.hadoop_version,
+                        spark_version: $row.spark_version,
+                        scala_version: $row.scala_version,
+                        java_version: $row.java_version
+                      })
+                  )
+              )'
+          )
 
           LENGHT=$(echo ${MATRIX} | jq '. | length')
           echo "${MATRIX}"

--- a/.github/workflows/build-image-template.yml
+++ b/.github/workflows/build-image-template.yml
@@ -44,6 +44,11 @@ on:
         description: Python version
         required: true
         type: string
+      packages:
+        description: Comma-separated list of extra maven style jars to bake into the Spark image.
+        required: false
+        type: string
+        default: ""
       publish_to_registry:
         description: Wheter to push to the registry
         required: false
@@ -63,15 +68,15 @@ on:
         required: false
         type: string
         default: ""
-      runs-on:
-        description: GitHub Actions Runner image
-        required: true
-        type: string
       enable_patch_pombump:
         description: Enable patch-pombump
         required: false
         type: boolean
         default: true
+      runs-on:
+        description: GitHub Actions Runner image
+        required: true
+        type: string
 
 jobs:
   
@@ -115,7 +120,7 @@ jobs:
           spark_version: ${{ inputs.spark_version}}
           scala_version: ${{ inputs.scala_version }}
           java_version: ${{ inputs.java_version }}
-          python_version: ${{ inputs.python_version}}
+          python_version: ${{ inputs.python_version }}
           ci_repo: ${{ steps.registry-repos.outputs.ci_repo }}
           publish_repo: ${{ steps.registry-repos.outputs.publish_repo }}
           publish_to_registry: ${{ inputs.publish_to_registry }}
@@ -152,6 +157,7 @@ jobs:
             JAVA_VERSION=${{ inputs.java_version }}
             PYTHON_VERSION=${{ inputs.python_version }}
             HADOOP_VERSION=${{ inputs.hadoop_version }}
+            SPARK_PACKAGES=${{ inputs.packages }}
             BASE_IMAGE=${{ steps.image-tags.outputs.parent_image }}
           tags: |
             ${{ steps.registry-repos.outputs.ci_repo }}/${{ inputs.image }}:${{ steps.image-tags.outputs.latest_tag }}
@@ -222,6 +228,7 @@ jobs:
             JAVA_VERSION=${{ inputs.java_version }}
             PYTHON_VERSION=${{ inputs.python_version }}
             HADOOP_VERSION=${{ inputs.hadoop_version }}
+            SPARK_PACKAGES=${{ inputs.packages }}
             BASE_IMAGE=${{ steps.image-tags.outputs.parent_image }}
           tags: ${{ steps.image-tags.outputs.publish_tags }}
           labels: |

--- a/.github/workflows/build-images-template.yml
+++ b/.github/workflows/build-images-template.yml
@@ -39,6 +39,11 @@ on:
         description: Python version
         required: true
         type: string
+      packages:
+        description: Comma-separated list of extra maven style jars to bake into the Spark image.
+        required: false
+        type: string
+        default: ""
       registry:
         description: The container registry 
         required: false
@@ -86,6 +91,7 @@ jobs:
       java_version: ${{ inputs.java_version }}
       scala_version: ${{ inputs.scala_version }}
       hadoop_version: ${{ inputs.hadoop_version }}
+      packages: ${{ inputs.packages }}
       registry: ${{ inputs.registry }}
       publish_to_registry: ${{ inputs.publish_to_registry }}
       git_latest_release_tag: ${{ inputs.git_latest_release_tag }}

--- a/.github/workflows/build-upload-spark-dist.yml
+++ b/.github/workflows/build-upload-spark-dist.yml
@@ -82,7 +82,8 @@ jobs:
 
       - name: Build spark distribution from Spark image
         run: |
-          IMAGE="${{ inputs.registry }}/okdp/spark:spark-${{ inputs.spark_version }}-scala-${{ inputs.scala_version }}-java-${{ inputs.java_version }}"
+          repo_owner=${GITHUB_REPOSITORY_OWNER@L}"
+          IMAGE="${{ inputs.registry }}/${repo_owner}/spark:spark-${{ inputs.spark_version }}-scala-${{ inputs.scala_version }}-java-${{ inputs.java_version }}"
           SPARK_HOME=opt/spark
           
           echo "Pulling base image $IMAGE ..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,5 @@ jobs:
       java_version: ${{ matrix.version.java_version }}
       scala_version: ${{ matrix.version.scala_version }}
       hadoop_version: ${{ matrix.version.hadoop_version }}
+      packages: ${{ matrix.version.packages }}
       publish_to_registry: "false"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,7 @@ jobs:
       java_version: ${{ matrix.version.java_version }}
       scala_version: ${{ matrix.version.scala_version }}
       hadoop_version: ${{ matrix.version.hadoop_version }}
+      packages: ${{ matrix.version.packages }}
       registry: ${{ vars.REGISTRY || 'quay.io' }}
       publish_to_registry: "true"
       git_latest_release_tag: ${{ needs.latest-github-release.outputs.tag_name }}

--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -22,27 +22,146 @@ ARG REGISTRY=quay.io
 ARG REPO=okdp
 ARG BASE_IMAGE=${REGISTRY}/${REPO}/spark-base:spark-${SPARK_VERSION}-scala-${SCALA_VERSION}-java-${JAVA_VERSION}
 
-FROM $BASE_IMAGE
+FROM maven:3.9.11-eclipse-temurin-17 AS builder
 
-ARG AUTH_FILTER_VERSION=1.4.2
-ARG JMX_JAVA_AGENT_VERSION=1.5.0
+ARG SPARK_PACKAGES="org.apache.iceberg:iceberg-spark-runtime-3.5_2.13:1.10.1,org.apache.iceberg:iceberg-aws-bundle:1.10.1,io.okdp:okdp-spark-auth-filter:1.4.2,https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar"
+
+WORKDIR /build
+
+RUN bash -eu -o pipefail <<'EOF'
+mkdir -p /build/target/jars
+
+# Split SPARK_PACKAGES on commas into one item per line.
+printf '%s' "${SPARK_PACKAGES:-}" | tr ',' '\n' > /build/packages.txt
+
+# Start with an empty dependency fragment.
+: > /build/dependencies.xml
+
+# Parse entries:
+# - http(s)://...                -> download directly
+# - group:artifact:version       -> Maven dependency
+# - group:artifact:version:type  -> Maven dependency with explicit type
+# - group:artifact:version:type:classifier -> Maven dependency with type + classifier
+while IFS= read -r raw; do
+  item="$(printf '%s' "$raw" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [ -z "$item" ] && continue
+
+  case "$item" in
+    http://*|https://*)
+      file_name="$(basename "${item%%\?*}")"
+      curl -fsSL "$item" -o "/build/target/jars/${file_name}"
+      ;;
+    *)
+      IFS=':' read -r -a parts <<< "$item"
+      count="${#parts[@]}"
+
+      if [ "$count" -lt 3 ] || [ "$count" -gt 5 ]; then
+        echo "Unsupported package entry: $item" >&2
+        echo "Expected Maven coordinate forms:" >&2
+        echo "  groupId:artifactId:version" >&2
+        echo "  groupId:artifactId:version:type" >&2
+        echo "  groupId:artifactId:version:type:classifier" >&2
+        echo "Or a direct http(s) jar URL." >&2
+        exit 1
+      fi
+
+      group_id="${parts[0]}"
+      artifact_id="${parts[1]}"
+      version="${parts[2]}"
+      type=""
+      classifier=""
+
+      if [ "$count" -ge 4 ]; then
+        type="${parts[3]}"
+      fi
+
+      if [ "$count" -eq 5 ]; then
+        classifier="${parts[4]}"
+      fi
+
+      {
+        echo "    <dependency>"
+        echo "      <groupId>${group_id}</groupId>"
+        echo "      <artifactId>${artifact_id}</artifactId>"
+        echo "      <version>${version}</version>"
+        if [ -n "$type" ]; then
+          echo "      <type>${type}</type>"
+        fi
+        if [ -n "$classifier" ]; then
+          echo "      <classifier>${classifier}</classifier>"
+        fi
+        echo "    </dependency>"
+      } >> /build/dependencies.xml
+      ;;
+  esac
+done < /build/packages.txt
+
+cat > /build/pom.xml <<'POM'
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>local.spark.image</groupId>
+  <artifactId>dynamic-spark-runtime-dependencies</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+POM
+
+cat /build/dependencies.xml >> /build/pom.xml
+
+cat >> /build/pom.xml <<'POM'
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.10.0</version>
+        <executions>
+          <execution>
+            <id>copy-runtime-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+              <outputDirectory>${project.build.directory}/jars</outputDirectory>
+              <excludeTransitive>false</excludeTransitive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+POM
+
+# Always run Maven; it succeeds even if there are no Maven dependencies.
+mvn -B -q -f /build/pom.xml package
+EOF
+
+FROM $BASE_IMAGE
 
 ENV JMX_CONF_DIR=/etc/metrics/conf/
 
-# OKDP addons
-RUN set -eux; \
-    cd ${SPARK_HOME}/jars/; \
-    curl -fsSL "https://repo1.maven.org/maven2/io/okdp/okdp-spark-auth-filter/${AUTH_FILTER_VERSION}/okdp-spark-auth-filter-${AUTH_FILTER_VERSION}.jar" \
-      -o "okdp-spark-auth-filter-${AUTH_FILTER_VERSION}.jar"; \
-    curl -fsSL "https://github.com/prometheus/jmx_exporter/releases/download/${JMX_JAVA_AGENT_VERSION}/jmx_prometheus_javaagent-${JMX_JAVA_AGENT_VERSION}.jar" \
-      -o "jmx_prometheus_javaagent-${JMX_JAVA_AGENT_VERSION}.jar";
+# Copy resolved and downloaded jars into Spark.
+COPY --from=builder /build/target/jars/ ${SPARK_HOME}/jars/
 
-# Jmx prometheus metrics
+# JMX Prometheus metrics config
 COPY --chown=spark:spark metrics.properties ${JMX_CONF_DIR}/metrics.properties
 COPY --chown=spark:spark prometheus.yaml    ${JMX_CONF_DIR}/prometheus.yaml
 
-# Add symkink for jmx_prometheus_agent
-RUN ln -s "$SPARK_HOME/jars/jmx_prometheus_javaagent-"*.jar \
-          "$SPARK_HOME/jars/jmx_prometheus_javaagent.jar"
+# Add symlink for jmx_prometheus_javaagent only when present
+RUN set -eux; \
+    agent_file="$(find "${SPARK_HOME}/jars" -maxdepth 1 -type f -name 'jmx_prometheus_javaagent-*.jar' | head -n 1 || true)"; \
+    if [ -n "${agent_file}" ]; then \
+      ln -sf "${agent_file}" "${SPARK_HOME}/jars/jmx_prometheus_javaagent.jar"; \
+    fi
 
 USER spark


### PR DESCRIPTION
This PR adds dynamic Spark package resolution to the image build pipeline and extends the Spark version matrix with package definitions for Iceberg-based access through Polaris. 

The build now accepts a package list, resolves Maven coordinates transitively, downloads direct jar URLs as-is, and copies the resulting jars into the Spark image at build time. This removes the need to hardcode individual addon downloads in the Dockerfile and makes package selection driven by the CI.

For Polaris integration, this PR adopts the [Iceberg REST](https://iceberg.apache.org/multi-engine-support/#apache-spark)  path as the default for Spark. 

> ℹ️ NOTE
>
> Polaris documents two Spark access paths:
> 
> 1. The [Iceberg REST](https://iceberg.apache.org/multi-engine-support/#apache-spark) path for Iceberg tables, using the  Iceberg Spark runtime (iceberg-spark-runtime-*) against Polaris as an Iceberg REST catalog.
> 2. The [Generic Tables](https://polaris.apache.org/in-dev/unreleased/polaris-spark-client) path via the Polaris Spark client for non-Iceberg tables (Delta). This path can manage both Iceberg tables and non-Iceberg (Delta) tables.



