### PR TITLE
fix(ci): harden GitHub Actions security and add Trivy scan

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
         # this might remove tools that are actually needed,
         # if set to "true" but frees about 6 GB
@@ -35,6 +35,5 @@ runs:
         large-packages: true
         docker-images: true
         swap-storage: true
-
 
 

--- a/.github/actions/setup-buildx/action.yaml
+++ b/.github/actions/setup-buildx/action.yaml
@@ -21,9 +21,9 @@ runs:
   using: composite
   steps:
     - name: Set up QEMU 📦
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
     - name: Set up Docker Buildx 📦
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       with:
         driver-opts: network=host

--- a/.github/actions/setup-kind/action.yaml
+++ b/.github/actions/setup-kind/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         # https://github.com/helm/kind-action?tab=readme-ov-file#inputs
         verbosity: 10

--- a/.github/actions/spark-image-tag/action.yaml
+++ b/.github/actions/spark-image-tag/action.yaml
@@ -62,16 +62,19 @@ runs:
   steps:
     - name: Install yq
       run: |
-         sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_amd64
-         sudo chmod a+x /usr/local/bin/yq
+         YQ_VERSION="v4.53.3"
+         YQ_SHA256="fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+         curl -fsSLo yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+         echo "${YQ_SHA256}  yq" | sha256sum -c -
+         sudo install -m 0755 yq /usr/local/bin/yq
       shell: bash
       
     - name: Expose git commit sha as env variable
-      uses: rlespinasse/git-commit-data-action@v1.5.0
+      uses: rlespinasse/git-commit-data-action@2b76766acf9574c24b5cec7608be8db5dc17968e # v1.5.0
 
     - name: Get current branch 📦
       id: git-branch
-      uses: tj-actions/branch-names@v8
+      uses: tj-actions/branch-names@5250492686b253f06fa55861556d1027b067aeb5 # v9.0.2
 
     - name: Generate spark image tags 📦
       id: tags

--- a/.github/actions/spark-tests-prepare/action.yml
+++ b/.github/actions/spark-tests-prepare/action.yml
@@ -38,13 +38,13 @@ runs:
   # https://github.com/apache/spark/blob/master/.github/workflows/build_and_test.yml
   steps:
     - name: Set up Java ${{ inputs.java_version }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
         java-version: ${{ inputs.java_version }}
 
     - name: Set up R for integration tests
-      uses: r-lib/actions/setup-r@v2
+      uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
 
     - name: Install R dependencies
       run: |
@@ -53,7 +53,7 @@ runs:
       shell: bash
 
     - name: Cache Scala, SBT and Maven
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           build/apache-maven-*
@@ -63,10 +63,9 @@ runs:
         key: build-${{ inputs.spark_version }}-scala${{ inputs.scala_version }}-java${{ inputs.java_version }}
 
     - name: Cache Coursier local repository
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/coursier
         key: build-${{ inputs.spark_version }}-scala${{ inputs.scala_version }}-java${{ inputs.java_version }}-coursier
-
 
 

--- a/.github/actions/spark-trivy-matrix/action.yaml
+++ b/.github/actions/spark-trivy-matrix/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: The matrix version file to use
     required: false
     default: ".build/release-versions.yml"
+  images_file:
+    description: The image tag definition file to use
+    required: false
+    default: ".build/images.yml"
   git_tag_name:
     description: The Git remote latest tag name
     required: true
@@ -29,6 +33,9 @@ inputs:
     description: The container registry
     required: false
     default: "quay.io"
+  repository_owner:
+    description: The repository owner used to build published image references
+    required: true
 
 outputs:
   spark_base_matrix:
@@ -49,8 +56,11 @@ runs:
   steps:
     - name: Install yq
       run: |
-        sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_amd64
-        sudo chmod a+x /usr/local/bin/yq
+        YQ_VERSION="v4.53.3"
+        YQ_SHA256="fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+        curl -fsSLo yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+        echo "${YQ_SHA256}  yq" | sha256sum -c -
+        sudo install -m 0755 yq /usr/local/bin/yq
       shell: bash
 
     - name: Get release versions matrix 📥
@@ -63,12 +73,14 @@ runs:
       id: scan-matrix
       env:
         GIT_TAG_NAME: ${{ inputs.git_tag_name }}
+        IMAGES_FILE: ${{ inputs.images_file }}
         RELEASE_MATRIX: ${{ steps.release-versions.outputs.matrix }}
         REGISTRY: ${{ inputs.registry }}
+        REPOSITORY_OWNER: ${{ inputs.repository_owner }}
       run: |
         set -euo pipefail
 
-        repo_owner="$(printf "%s" "${GITHUB_REPOSITORY_OWNER}" | tr "[:upper:]" "[:lower:]")"
+        repo_owner="$(printf "%s" "${REPOSITORY_OWNER}" | tr "[:upper:]" "[:lower:]")"
         publish_repo="${REGISTRY}/${repo_owner}"
         git_release_version="${GIT_TAG_NAME#v}"
 
@@ -87,7 +99,7 @@ runs:
           local tags
           local date_token
 
-          tags="$(yq -oj ".images[] | select(.name == \"${image}\").tags" .build/images.yml | jq -r '.[]')"
+          tags="$(yq -oj ".images[] | select(.name == \"${image}\").tags" "${IMAGES_FILE}" | jq -r '.[]')"
           date_token="\$(date '+%Y-%m-%d')"
 
           while read -r tag_template; do

--- a/.github/actions/spark-trivy-matrix/action.yaml
+++ b/.github/actions/spark-trivy-matrix/action.yaml
@@ -1,0 +1,149 @@
+#
+# Copyright 2026 The OKDP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Build Spark Trivy scan matrices
+description: Build Trivy scan matrices for published Spark image tags
+
+inputs:
+  use_matrix:
+    description: The matrix version file to use
+    required: false
+    default: ".build/release-versions.yml"
+  git_tag_name:
+    description: The Git remote latest tag name
+    required: true
+  registry:
+    description: The container registry
+    required: false
+    default: "quay.io"
+
+outputs:
+  spark_base_matrix:
+    description: Trivy scan matrix for spark-base
+    value: ${{ steps.scan-matrix.outputs.spark_base_matrix }}
+  spark_matrix:
+    description: Trivy scan matrix for spark
+    value: ${{ steps.scan-matrix.outputs.spark_matrix }}
+  spark_py_matrix:
+    description: Trivy scan matrix for spark-py
+    value: ${{ steps.scan-matrix.outputs.spark_py_matrix }}
+  spark_r_matrix:
+    description: Trivy scan matrix for spark-r
+    value: ${{ steps.scan-matrix.outputs.spark_r_matrix }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install yq
+      run: |
+        sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_amd64
+        sudo chmod a+x /usr/local/bin/yq
+      shell: bash
+
+    - name: Get release versions matrix 📥
+      id: release-versions
+      uses: ./.github/actions/spark-version-matrix
+      with:
+        use_matrix: ${{ inputs.use_matrix }}
+
+    - name: Generate Trivy scan matrix 📦
+      id: scan-matrix
+      env:
+        GIT_TAG_NAME: ${{ inputs.git_tag_name }}
+        RELEASE_MATRIX: ${{ steps.release-versions.outputs.matrix }}
+        REGISTRY: ${{ inputs.registry }}
+      run: |
+        set -euo pipefail
+
+        repo_owner="$(printf "%s" "${GITHUB_REPOSITORY_OWNER}" | tr "[:upper:]" "[:lower:]")"
+        publish_repo="${REGISTRY}/${repo_owner}"
+        git_release_version="${GIT_TAG_NAME#v}"
+
+        spark_base_matrix="$(mktemp)"
+        spark_matrix="$(mktemp)"
+        spark_py_matrix="$(mktemp)"
+        spark_r_matrix="$(mktemp)"
+        echo '{"include":[]}' > "${spark_base_matrix}"
+        echo '{"include":[]}' > "${spark_matrix}"
+        echo '{"include":[]}' > "${spark_py_matrix}"
+        echo '{"include":[]}' > "${spark_r_matrix}"
+
+        append_image_tags() {
+          local matrix_file="$1"
+          local image="$2"
+          local tags
+          local date_token
+
+          tags="$(yq -oj ".images[] | select(.name == \"${image}\").tags" .build/images.yml | jq -r '.[]')"
+          date_token="\$(date '+%Y-%m-%d')"
+
+          while read -r tag_template; do
+            local tag
+            local image_ref
+            local image_tag
+
+            if [[ "${tag_template}" == *"${date_token}"* ]]; then
+              continue
+            fi
+
+            tag="$(eval echo "${tag_template}")"
+            image_ref="${publish_repo}/${image}:${tag}"
+            image_tag="${image}-${tag}"
+            image_tag="${image_tag//[^a-zA-Z0-9_.-]/-}"
+
+            jq \
+              --arg image "${image_ref}" \
+              --arg image_tag "${image_tag}" \
+              --arg image_name "${image}" \
+              --arg spark_version "${spark_version}" \
+              '.include += [{
+                image: $image,
+                image_tag: $image_tag,
+                image_name: $image_name,
+                spark_version: $spark_version
+              }]' \
+              "${matrix_file}" > "${matrix_file}.next"
+            mv "${matrix_file}.next" "${matrix_file}"
+          done <<< "${tags}"
+        }
+
+        while read -r version; do
+          spark_version="$(jq -r '.spark_version' <<< "${version}")"
+          scala_version="$(jq -r '.scala_version' <<< "${version}")"
+          java_version="$(jq -r '.java_version' <<< "${version}")"
+          python_version="$(jq -r '.python_version' <<< "${version}")"
+          r_version=""
+
+          append_image_tags "${spark_base_matrix}" "spark-base"
+          append_image_tags "${spark_matrix}" "spark"
+          append_image_tags "${spark_py_matrix}" "spark-py"
+          append_image_tags "${spark_r_matrix}" "spark-r"
+        done < <(jq -c '.[]' <<< "${RELEASE_MATRIX}")
+
+        spark_base_json="$(jq -c '.' "${spark_base_matrix}")"
+        spark_json="$(jq -c '.' "${spark_matrix}")"
+        spark_py_json="$(jq -c '.' "${spark_py_matrix}")"
+        spark_r_json="$(jq -c '.' "${spark_r_matrix}")"
+
+        echo "Generated $(jq '.include | length' <<< "${spark_base_json}") spark-base image scans"
+        echo "Generated $(jq '.include | length' <<< "${spark_json}") spark image scans"
+        echo "Generated $(jq '.include | length' <<< "${spark_py_json}") spark-py image scans"
+        echo "Generated $(jq '.include | length' <<< "${spark_r_json}") spark-r image scans"
+        echo "spark_base_matrix=${spark_base_json}" >> "${GITHUB_OUTPUT}"
+        echo "spark_matrix=${spark_json}" >> "${GITHUB_OUTPUT}"
+        echo "spark_py_matrix=${spark_py_json}" >> "${GITHUB_OUTPUT}"
+        echo "spark_r_matrix=${spark_r_json}" >> "${GITHUB_OUTPUT}"
+      shell: bash

--- a/.github/workflows/build-image-template.yml
+++ b/.github/workflows/build-image-template.yml
@@ -84,18 +84,20 @@ jobs:
     name: ${{ inputs.image }} (scala-${{ inputs.scala_version }}, java-${{ inputs.java_version }}, python-${{ inputs.python_version }}, hadoop-${{ inputs.hadoop_version }})
     runs-on: ${{ inputs.runs-on }}
     steps:
-
       ### The publish and periodic rebuilds are based on the latest stable github release tag
       - name: Checkout latest Github Release tag (${{ inputs.git_latest_release_tag }}) ⚡️
         if: inputs.publish_to_registry == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.git_latest_release_tag }}
+          persist-credentials: false
       
       ### The CI is based on the main branch
       - name: Checkout Repo ⚡️
         if: inputs.publish_to_registry == 'false'
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       ### Common steps between CI and Publish
       - name: Free up disk space 📦
@@ -128,7 +130,7 @@ jobs:
 
       - name: Login to the CI registry 🔐
         if: inputs.publish_to_registry == 'false'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ inputs.ci_registry }}
           username: ${{ github.actor }}
@@ -146,7 +148,7 @@ jobs:
 
       - name: Build and push to ci registry
         if: inputs.publish_to_registry == 'false'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ inputs.image }}
           platforms: linux/amd64,linux/arm64           
@@ -209,7 +211,7 @@ jobs:
       ### The publish and periodic rebuilds are based on the latest stable github release tag
       - name: Login into official registry 🔐
         if: inputs.publish_to_registry == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -217,7 +219,7 @@ jobs:
 
       - name: Build and push to official registry 📤
         if: inputs.publish_to_registry == 'true'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ inputs.image }}
           platforms: linux/amd64,linux/arm64   
@@ -238,4 +240,3 @@ jobs:
             org.opencontainers.image.base.name="${{ steps.image-tags.outputs.parent_image }}"
             org.opencontainers.image.source="https://github.com/${{ github.repository }}"
             org.opencontainers.image.licenses="Apache-2.0"
-

--- a/.github/workflows/build-upload-spark-dist.yml
+++ b/.github/workflows/build-upload-spark-dist.yml
@@ -60,9 +60,10 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout latest Github Release tag (${{ inputs.git_latest_release_tag }}) ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.git_latest_release_tag }}
+          persist-credentials: false
 
       - name: Set Spark distribution name
         run: |
@@ -112,4 +113,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  packages: write
+  contents: read
   
 jobs:
 
@@ -60,7 +60,9 @@ jobs:
       matrix: ${{ steps.ci-versions.outputs.matrix }}
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Get CI versions matrix 📥
         id: ci-versions
@@ -71,6 +73,9 @@ jobs:
   spark-ci:
     name: spark-ci (spark-${{ matrix.version.spark_version }})
     needs: [get-ci-versions]
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix: 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  packages: write
-  contents: write
+  contents: read
 
 jobs:
   
@@ -51,11 +50,13 @@ jobs:
       tag_name: ${{ steps.git-release-tag.outputs.tag_name }}
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Get latest GitHub Release tag name 📥
         id: git-release-tag
-        uses: InsonusK/get-latest-release@v1.1.0
+        uses: InsonusK/get-latest-release@7a9ff16c8c6b7ead5d71c0f1cc61f2703170eade # v1.1.0
         with:
           myToken: ${{ github.token }}
           exclude_types: "draft"
@@ -78,7 +79,9 @@ jobs:
       matrix: ${{ steps.release-versions.outputs.matrix }}
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Get release versions matrix 📥
         id: release-versions
@@ -90,6 +93,9 @@ jobs:
     if: github.repository_owner == 'OKDP' && needs.latest-github-release.outputs.tag_name != ''
     name: spark-images-publish (${{ needs.latest-github-release.outputs.tag_name }}/spark-${{ matrix.version.spark_version }})
     needs: [latest-github-release, get-release-versions]
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix: 
@@ -111,6 +117,8 @@ jobs:
     if: github.repository_owner == 'OKDP' && needs.latest-github-release.outputs.tag_name != ''
     name: spark-dist-publish (${{ needs.latest-github-release.outputs.tag_name }}/spark-${{ matrix.version.spark_version }})
     needs: [latest-github-release, get-release-versions, spark-images-publish]
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,8 +24,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -40,6 +39,9 @@ defaults:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}
@@ -47,7 +49,7 @@ jobs:
     # The pull request should come from the same repo (github_token from the fork does not have write permissions)
     if: github.repository_owner == 'OKDP' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release-please
 
   publish:
@@ -55,9 +57,8 @@ jobs:
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
     permissions:
-      contents: write
       actions: write
-      packages: write
+      contents: read
     steps:
       - name: "Publish images to official registry"
         env:
@@ -67,4 +68,3 @@ jobs:
         run: |
           gh workflow run publish.yml
         shell: bash
-      

--- a/.github/workflows/sign-images.yml
+++ b/.github/workflows/sign-images.yml
@@ -28,7 +28,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  packages: write
   contents: read
 
 jobs:
@@ -38,7 +37,9 @@ jobs:
       matrix: ${{ steps.ci-versions.outputs.matrix }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
         
       - name: Get CI versions matrix
         id: ci-versions
@@ -50,6 +51,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     needs: [get-ci-versions]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +62,9 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up CI registry
         id: registry-repos
@@ -79,24 +85,27 @@ jobs:
           publish_to_registry: "false"
 
       - name: Login to CI registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install tools
+      - name: Install Syft
+        id: syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.45.1
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.1
+
+      - name: Install jq
         run: |
-          # Install syft
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
-          
-          # Install cosign
-          wget -q https://github.com/sigstore/cosign/releases/download/v2.1.1/cosign-linux-amd64
-          chmod +x cosign-linux-amd64
-          sudo mv cosign-linux-amd64 /usr/local/bin/cosign
-          
-          # Install jq for JSON validation
-          sudo apt-get update && sudo apt-get install -y jq
+          sudo apt-get update
+          sudo apt-get install -y jq
 
       - name: Generate cosign keypair
         run: |
@@ -111,6 +120,8 @@ jobs:
 
       - name: Pull and generate SBOM
         id: sbom
+        env:
+          SYFT_CMD: ${{ steps.syft.outputs.cmd }}
         run: |
           # Set image URL
           IMAGE_URL="${{ steps.registry-repos.outputs.ci_repo }}/${{ matrix.image }}:${{ steps.image-tags.outputs.latest_tag }}"
@@ -123,7 +134,7 @@ jobs:
           # Generate SBOM
           echo "Generating SBOM..."
           SBOM_FILE="${{ matrix.image }}-${{ steps.image-tags.outputs.latest_tag }}.sbom.json"
-          syft ${IMAGE_URL} -o spdx-json > ${SBOM_FILE}
+          "${SYFT_CMD}" ${IMAGE_URL} -o spdx-json > ${SBOM_FILE}
           echo "sbom_file=${SBOM_FILE}" >> $GITHUB_OUTPUT
           echo "✅ SBOM generated: ${SBOM_FILE}"
 
@@ -279,12 +290,11 @@ jobs:
           echo "name=signing-artifacts-${{ matrix.image }}-${{ matrix.version.spark_version }}-${TIMESTAMP}" >> $GITHUB_OUTPUT
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true  # Make this step non-fatal
         with:
           name: ${{ steps.artifact-name.outputs.name }}
           path: |
             ${{ steps.sbom.outputs.sbom_file }}
-            cosign.key
             cosign.pub
           retention-days: 30

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,7 +30,6 @@ concurrency:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   latest-github-release:
@@ -40,7 +39,9 @@ jobs:
       tag_name: ${{ steps.git-release-tag.outputs.tag_name }}
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Get latest GitHub Release tag name 📥
         id: git-release-tag
@@ -71,27 +72,35 @@ jobs:
       spark_r_matrix: ${{ steps.spark-trivy-matrix.outputs.spark_r_matrix }}
     steps:
       - name: Checkout latest Github Release tag (${{ needs.latest-github-release.outputs.tag_name }}) ⚡️
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Generate Trivy scan matrices 📦
         id: spark-trivy-matrix
         uses: ./.github/actions/spark-trivy-matrix
         with:
           use_matrix: ".build/release-versions.yml"
+          images_file: ".build/images.yml"
           git_tag_name: ${{ needs.latest-github-release.outputs.tag_name }}
           registry: ${{ vars.REGISTRY || 'quay.io' }}
+          repository_owner: ${{ github.repository_owner }}
 
   spark-base:
     if: github.repository_owner == 'OKDP' && needs.generate-trivy-matrix.outputs.spark_base_matrix != '{"include":[]}'
     name: spark-base (${{ needs.latest-github-release.outputs.tag_name }}/${{ matrix.spark_version }})
     needs: [latest-github-release, generate-trivy-matrix]
     runs-on: "ubuntu-latest"
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-trivy-matrix.outputs.spark_base_matrix) }}
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ matrix.image }}
           format: sarif
@@ -99,7 +108,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
           category: trivy-spark-base-${{ matrix.image_tag }}
@@ -109,12 +118,16 @@ jobs:
     name: spark (${{ needs.latest-github-release.outputs.tag_name }}/${{ matrix.spark_version }})
     needs: [latest-github-release, generate-trivy-matrix]
     runs-on: "ubuntu-latest"
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-trivy-matrix.outputs.spark_matrix) }}
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ matrix.image }}
           format: sarif
@@ -122,7 +135,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
           category: trivy-spark-${{ matrix.image_tag }}
@@ -132,12 +145,16 @@ jobs:
     name: spark-py (${{ needs.latest-github-release.outputs.tag_name }}/${{ matrix.spark_version }})
     needs: [latest-github-release, generate-trivy-matrix]
     runs-on: "ubuntu-latest"
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-trivy-matrix.outputs.spark_py_matrix) }}
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ matrix.image }}
           format: sarif
@@ -145,7 +162,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
           category: trivy-spark-py-${{ matrix.image_tag }}
@@ -155,12 +172,16 @@ jobs:
     name: spark-r (${{ needs.latest-github-release.outputs.tag_name }}/${{ matrix.spark_version }})
     needs: [latest-github-release, generate-trivy-matrix]
     runs-on: "ubuntu-latest"
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-trivy-matrix.outputs.spark_r_matrix) }}
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ matrix.image }}
           format: sarif
@@ -168,7 +189,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
           category: trivy-spark-r-${{ matrix.image_tag }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -106,6 +106,8 @@ jobs:
           format: sarif
           output: trivy-results-${{ matrix.image_tag }}.sarif
           severity: CRITICAL,HIGH
+          scanners: vuln
+          timeout: 20m
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,174 @@
+#
+# Copyright 2026 The OKDP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: trivy
+
+on:
+  workflow_run:
+    workflows: ["publish"]
+    types:
+      - completed
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  latest-github-release:
+    if: github.repository_owner == 'OKDP' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    runs-on: "ubuntu-latest"
+    outputs:
+      tag_name: ${{ steps.git-release-tag.outputs.tag_name }}
+    steps:
+      - name: Checkout Repo ⚡️
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Get latest GitHub Release tag name 📥
+        id: git-release-tag
+        uses: InsonusK/get-latest-release@7a9ff16c8c6b7ead5d71c0f1cc61f2703170eade # v1.1.0
+        with:
+          myToken: ${{ github.token }}
+          exclude_types: "draft"
+          view_top: 1
+
+      - name: Info - Found latest release tag
+        run: |
+          echo "id: ${{ steps.git-release-tag.outputs.id }}"
+          echo "name: ${{ steps.git-release-tag.outputs.name }}"
+          echo "tag_name: ${{ steps.git-release-tag.outputs.tag_name }}"
+          echo "created_at: ${{ steps.git-release-tag.outputs.created_at }}"
+          echo "draft: ${{ steps.git-release-tag.outputs.draft }}"
+          echo "prerelease: ${{ steps.git-release-tag.outputs.prerelease }}"
+        shell: bash
+
+  generate-trivy-matrix:
+    if: github.repository_owner == 'OKDP' && needs.latest-github-release.outputs.tag_name != ''
+    needs: [latest-github-release]
+    runs-on: "ubuntu-latest"
+    outputs:
+      spark_base_matrix: ${{ steps.spark-trivy-matrix.outputs.spark_base_matrix }}
+      spark_matrix: ${{ steps.spark-trivy-matrix.outputs.spark_matrix }}
+      spark_py_matrix: ${{ steps.spark-trivy-matrix.outputs.spark_py_matrix }}
+      spark_r_matrix: ${{ steps.spark-trivy-matrix.outputs.spark_r_matrix }}
+    steps:
+      - name: Checkout latest Github Release tag (${{ needs.latest-github-release.outputs.tag_name }}) ⚡️
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Generate Trivy scan matrices 📦
+        id: spark-trivy-matrix
+        uses: ./.github/actions/spark-trivy-matrix
+        with:
+          use_matrix: ".build/release-versions.yml"
+          git_tag_name: ${{ needs.latest-github-release.outputs.tag_name }}
+          registry: ${{ vars.REGISTRY || 'quay.io' }}
+
+  spark-base:
+    if: github.repository_owner == 'OKDP' && needs.generate-trivy-matrix.outputs.spark_base_matrix != '{"include":[]}'
+    name: spark-base (${{ needs.latest-github-release.outputs.tag_name }}/${{ matrix.spark_version }})
+    needs: [latest-github-release, generate-trivy-matrix]
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-trivy-matrix.outputs.spark_base_matrix) }}
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: trivy-results-${{ matrix.image_tag }}.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        with:
+          sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
+          category: trivy-spark-base-${{ matrix.image_tag }}
+
+  spark:
+    if: github.repository_owner == 'OKDP' && needs.generate-trivy-matrix.outputs.spark_matrix != '{"include":[]}'
+    name: spark (${{ needs.latest-github-release.outputs.tag_name }}/${{ matrix.spark_version }})
+    needs: [latest-github-release, generate-trivy-matrix]
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-trivy-matrix.outputs.spark_matrix) }}
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: trivy-results-${{ matrix.image_tag }}.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        with:
+          sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
+          category: trivy-spark-${{ matrix.image_tag }}
+
+  spark-py:
+    if: github.repository_owner == 'OKDP' && needs.generate-trivy-matrix.outputs.spark_py_matrix != '{"include":[]}'
+    name: spark-py (${{ needs.latest-github-release.outputs.tag_name }}/${{ matrix.spark_version }})
+    needs: [latest-github-release, generate-trivy-matrix]
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-trivy-matrix.outputs.spark_py_matrix) }}
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: trivy-results-${{ matrix.image_tag }}.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        with:
+          sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
+          category: trivy-spark-py-${{ matrix.image_tag }}
+
+  spark-r:
+    if: github.repository_owner == 'OKDP' && needs.generate-trivy-matrix.outputs.spark_r_matrix != '{"include":[]}'
+    name: spark-r (${{ needs.latest-github-release.outputs.tag_name }}/${{ matrix.spark_version }})
+    needs: [latest-github-release, generate-trivy-matrix]
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-trivy-matrix.outputs.spark_r_matrix) }}
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: trivy-results-${{ matrix.image_tag }}.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        with:
+          sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
+          category: trivy-spark-r-${{ matrix.image_tag }}


### PR DESCRIPTION
## Description

This PR hardens the GitHub Actions security configuration and adds a Trivy scan for published Spark images.

Changes included:

* Adds Trivy scanning for published Spark images.
* Hardens GitHub Actions permissions.
* Fixes permissions inheritance so workflows use safer permission defaults.
* Improves CI security posture without changing the Spark image build logic.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / chore
* [ ] Breaking change

<!-- If breaking change, describe the impact and migration path here: -->

## How to Test

A reviewer can verify this change by:

1. Open the branch: https://github.com/idirze/spark-images/tree/ci/trivy
2. Check that the GitHub Actions workflow permissions are explicitly hardened.
3. Check that the Trivy scan workflow/job targets the published Spark images.
4. Run or review the GitHub Actions CI execution for this branch.
5. Confirm that the Trivy scan completes successfully or reports vulnerabilities as expected.
6. Confirm that no image build behavior is changed by this PR.

<!-- TODO: replace CONTRIBUTING.md feature branch link to main once merged -->

## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->

* [x] I have tested my changes
* [x] Documentation updated if needed
* [x] If breaking change: migration path described above
* [x] I hereby declare this contribution to be licensed under the [[Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)](http://www.apache.org/licenses/LICENSE-2.0).
* [x] I hereby agree to grant [[TOSIT](https://www.tosit.io/)](https://www.tosit.io/) a copyright license to use my contributions.